### PR TITLE
Fixed explorer url protocol conditional

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -163,7 +163,7 @@ utils.request = function(options, callback) {
     uri.path = uri.pathname + '?' + qs.stringify(query);
   }
 
-  var protocol = uri.prototype === 'https:'
+  var protocol = uri.protocol === 'https:'
     ? require('https')
     : http;
 


### PR DESCRIPTION
I tried to explore the blockchain and found out it was receiving a 302 instead of 200 because it wasn't using https requests.